### PR TITLE
Replace .fail() with .then(undefined, callback) (for compatibility) and return a promise

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# http://editorconfig.org/
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 node_js:
-  - "0.11"
+  - stable
+  - 4
+  - 3
+  - 2
+  - 1
+  - "0.12"
   - "0.10"
-  - "0.8"
+sudo: false # allows for faster builds

--- a/index.js
+++ b/index.js
@@ -1,81 +1,100 @@
+if (typeof Promise === 'undefined') {
+  var Promise = require('promise')
+}
+
+function noop() {}
+
 module.exports = resolve
 
-function resolve (object, callback) {
+function resolve (object, _callback) {
+  if (typeof _callback != 'function') {
+    _callback = noop
+  }
+
   // If the property is not an object,
   // it needs no further processing.
   if (object === null || !isObject(object)) {
-    return callback(null, object)
+    return _callback(null, object)
   }
 
-  // If it is a promise, wait for it to resolve.
-  // Run the check again to find nested promises.
-  if (isPromise(object)) {
-    return object
-      .then(checkAgain.bind(null, null))
-      .fail(callback)
-  }
-
-  // If it has a toJSON method, assume it can be used directly.
-  if (canJSON(object)) {
-    object = object.toJSON()
-    if ( ! isObject(object)) {
-      return callback(null, object)
+  return new Promise(function(presolve, reject) {
+    var callback = function(err, res) {
+      if (err) {
+        reject(err);
+      } else {
+        presolve(res);
+      }
+      _callback(err, res)
     }
-  }
 
-  // Build a list of promises and promise-like structures to wait for.
-  var remains = []
-  Object.keys(object).forEach(function (key) {
-    var item = object[key]
-    if (isPromise(item) || isMongooseQuery(item) || isObject(item)) {
-      remains.push(key)
+    // If it is a promise, wait for it to resolve.
+    // Run the check again to find nested promises.
+    if (isPromise(object)) {
+      return object
+        .then(checkAgain.bind(null, null), callback)
     }
-  })
 
-  // If none were found, we must be done.
-  if ( ! remains.length) {
-    return callback(null, object)
-  }
-  
-  // Otherwise, loop through the list.
-  var pending = remains.length
-  remains.forEach(function (key) {
-    var item = object[key]
-
-    // Promises and queries must be checked again upon success
-    // to ensure nested promises are properly processed.
-    if (isPromise(item)) {
-      item
-        .then(doneHandler(key, checkAgain).bind(null, null))
-        .fail(doneHandler(key, callback))
-    } else if (isMongooseQuery(item)) {
-      item.exec(doneHandler(key, checkAgain))
-
-    // Other objects can simply be traversed directly.
-    } else {
-      resolve(item, doneHandler(key, callback))
-    }
-  })
-
-  // All the check to be restarted so we
-  // can return promises from promises.
-  function checkAgain (err, res) {
-    if (err) return callback(err)
-    resolve(res, callback)
-  }
-
-  // Promises need to call the restart the check,
-  // so we use this to allow them to swap out fn.
-  function doneHandler (key, fn) {
-    return function (err, result) {
-      if (err) return callback(err)
-
-      object[key] = result
-      if (--pending === 0) {
-        fn(null, object)
+    // If it has a toJSON method, assume it can be used directly.
+    if (canJSON(object)) {
+      object = object.toJSON()
+      if ( ! isObject(object)) {
+        return callback(null, object)
       }
     }
-  }
+
+    // Build a list of promises and promise-like structures to wait for.
+    var remains = []
+    Object.keys(object).forEach(function (key) {
+      var item = object[key]
+      if (isPromise(item) || isMongooseQuery(item) || isObject(item)) {
+        remains.push(key)
+      }
+    })
+
+    // If none were found, we must be done.
+    if ( ! remains.length) {
+      return callback(null, object)
+    }
+
+    // Otherwise, loop through the list.
+    var pending = remains.length
+    remains.forEach(function (key) {
+      var item = object[key]
+
+      // Promises and queries must be checked again upon success
+      // to ensure nested promises are properly processed.
+      if (isPromise(item)) {
+        item
+          .then(doneHandler(key, checkAgain).bind(null, null), doneHandler(key, callback))
+      } else if (isMongooseQuery(item)) {
+        item.exec(doneHandler(key, checkAgain))
+
+        // Other objects can simply be traversed directly.
+      } else {
+        resolve(item, doneHandler(key, callback))
+      }
+    })
+
+    // All the check to be restarted so we
+    // can return promises from promises.
+    function checkAgain (err, res) {
+      if (err) return callback(err)
+      resolve(res, callback)
+    }
+
+    // Promises need to call the restart the check,
+    // so we use this to allow them to swap out fn.
+    function doneHandler (key, fn) {
+      return function (err, result) {
+        if (err) return callback(err)
+
+        object[key] = result
+        if (--pending === 0) {
+          fn(null, object)
+        }
+      }
+    }
+  });
 }
 
 /**************************** HELPER METHODS **********************************/

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "q": "~1.0.0",
     "should": "~2.1.1",
     "istanbul": "~0.2.3"
+  },
+  "dependencies": {
+    "promise": "^7.0.4"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -107,6 +107,48 @@ describe('promise resolution', function () {
     })
   })
 
+  if (typeof Promise !== "undefined") {
+    it('should work with native promises', function (done) {
+      var p = new Promise(function(resolve, reject) {
+        process.nextTick(function () {
+          resolve('bar')
+        })
+      })
+
+      resolver({
+        foo: p
+      }, function (err, res) {
+        if (err) return done(err)
+        res.should.have.property('foo', 'bar')
+        done()
+      })
+    })
+  }
+
+  it('should return a promise', function () {
+    var p = Q.defer()
+
+    var res = resolver(p.promise)
+
+    res.should.have.property('then')
+    res.then.should.be.instanceof(Function)
+  })
+
+  it('should work without a callback', function (done) {
+    var p = Q.defer()
+
+    resolver({
+      foo: p.promise
+    }).then(function (res) {
+      res.should.have.property('foo', 'bar')
+      done()
+    }).catch(done)
+
+    process.nextTick(function () {
+      p.resolve('bar')
+    })
+  })
+
 })
 
 describe('graceful rejection', function () {


### PR DESCRIPTION
A couple of changes here:
- use `.then(undefined, callback)` instead of `.fail()` for wider compatibility
- return a promise (and not choke if the callback is undefined). Uses https://www.npmjs.com/package/promise if there isn't a global `Promise` object
- added tests for the above and updated travis to run against current versions of node.js
